### PR TITLE
Don't store full filepath for sounds

### DIFF
--- a/lib/bloc/audio/audio_bloc.dart
+++ b/lib/bloc/audio/audio_bloc.dart
@@ -332,9 +332,11 @@ class AudioNoteBloc extends Bloc<AudioNoteEvent, AudioNoteState> {
   }
 
   void _stopAudioEngine() async {
-    if (flutterSound.audioState == t_AUDIO_STATE.IS_PLAYING)
+    if (flutterSound.audioState == t_AUDIO_STATE.IS_PLAYING) {
       await flutterSound.stopPlayer();
-    if (flutterSound.audioState == t_AUDIO_STATE.IS_RECORDING)
+    }
+    if (flutterSound.audioState == t_AUDIO_STATE.IS_RECORDING) {
       await flutterSound.stopRecorder();
+    }
   }
 }

--- a/lib/storage/sound_storage.dart
+++ b/lib/storage/sound_storage.dart
@@ -25,15 +25,19 @@ class SoundStorage {
 
   SoundStorage({@required this.getDirectory, @required this.filenameGenerator});
 
-  Future<String> generateFilename() async {
+  Future<String> toFilePath(String filename) async {
     final dir = await getDirectory();
-    final filename = filenameGenerator();
     return "${dir.path}${Platform.pathSeparator}$filename";
   }
 
+  String generateFilename() {
+    return filenameGenerator();
+  }
+
   Future<FileSystemEntity> delete(String filename) async {
-    print("Deleting sound file: $filename");
-    final file = File(filename);
+    final filePath = await toFilePath(filename);
+    print("Deleting sound file: $filePath");
+    final file = File(filePath);
     return file.delete();
   }
 }


### PR DESCRIPTION
The actual directory path can change, so only store the filename and let the storage module determine the directory path.